### PR TITLE
Allow words starting with 'v' in most cases

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           cache: 'npm'
       - run: npm install
       # Build includes lint and test.

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v2

--- a/.github/workflows/publish-build.yml
+++ b/.github/workflows/publish-build.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout project'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
-      - name: 'Setup node 22.x'
-        uses: actions/setup-node@v4
+      - name: 'Setup node 24.x'
+        uses: actions/setup-node@v5
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: npm
 
       - name: 'Clean install project'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-05-21
+
+### Changed
+
+- Modified MemberStartsWithV rule to allow words starting with a 'v' unless
+  the second character in that word is in uppercase or if it is a number.
+
 ## [2.0.0] - 2026-01-09
 
 ### Added
@@ -97,6 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - PropertyLiteralCase psl-lint rule
 
 [Unreleased]: https://github.com/ing-bank/psl-linter/compare/v2.0.0...HEAD
+[2.1.0]: https://github.com/ing-bank/psl-linter/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/ing-bank/psl-linter/compare/3559ee427a52837baefcdb9b83cd3b97f8eb3324...v2.0.0
 <!--
 Links of the release below are before the project was split of the main

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@profile-psl/psl-linter",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@profile-psl/psl-linter",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@profile-psl/psl-parser": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@profile-psl/psl-linter",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Profile Scripting Language Linter",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/elementsConventionChecker.ts
+++ b/src/elementsConventionChecker.ts
@@ -223,11 +223,14 @@ export class MemberStartsWithV extends MemberRule {
 	}
 
 	checkStartsWithV(member: Member, diagnostics: Diagnostic[]): void {
-		if (member.id.value.charAt(0) !== "v") return;
+		// Allow words that start with v unless the second char is an uppercase or integer.
+		// For example: "v1whatever" or "vWhatever"
+		if (!/^v[0-9A-Z]/.test(member.id.value)) return;
 		if (isPublicDeclaration(member)) {
 			diagnostics.push(createDiagnostic(
 				member,
-				"is public and starts with 'v'.",
+				"is public and starts with '" +
+				member.id.value.slice(0, 2) + "'.",
 				DiagnosticSeverity.Information,
 				this.ruleName,
 			));
@@ -235,7 +238,8 @@ export class MemberStartsWithV extends MemberRule {
 		else {
 			diagnostics.push(createDiagnostic(
 				member,
-				"starts with 'v'.",
+				"starts with '" +
+				member.id.value.slice(0, 2) + "'.",
 				DiagnosticSeverity.Warning,
 				this.ruleName
 			));

--- a/test/convention.test.ts
+++ b/test/convention.test.ts
@@ -59,7 +59,7 @@ describe("Members tests", () => {
 		assert.strictEqual(diagnosticsOnLine.length,1);
 		assert.strictEqual(
 			diagnosticsOnLine[0].message,
-			'Declaration "vString" starts with \'v\'.'
+			'Declaration "vString" starts with \'vS\'.'
 		);
 		assert.strictEqual(diagnosticsOnLine[0].severity, api.DiagnosticSeverity.Warning);
 	});
@@ -68,7 +68,7 @@ describe("Members tests", () => {
 		assert.strictEqual(diagnosticsOnLine.length, 1);
 		assert.strictEqual(
 			diagnosticsOnLine[0].message,
-			'Declaration "vNumber" is public and starts with \'v\'.'
+			'Declaration "v9someNumber" is public and starts with \'v9\'.'
 		);
 		assert.strictEqual(
 			diagnosticsOnLine[0].severity,

--- a/test/files/ZTestConvention.PROC
+++ b/test/files/ZTestConvention.PROC
@@ -22,5 +22,5 @@ private void String methodInChild()
 	** ENDDOC */
 	type String y
 	type String vString
-	type public Number vNumber
+	type public Number v9someNumber
 	quit


### PR DESCRIPTION
This PR modifies the MemberStartsWithV rule to allow words starting with a 'v' unless the second character in that word is in uppercase or if it is a number. This will trigger a warning for words like "v1something" and "vSomething", while ignoring words such as "variable" and "verbose".