### PR TITLE
Use trusted publishers instead of tokens

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Use Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '24.x'
           cache: 'npm'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v2
+        uses: actions/dependency-review-action@v4

--- a/.github/workflows/publish-build.yml
+++ b/.github/workflows/publish-build.yml
@@ -8,20 +8,14 @@ on:
 jobs:
   publish-release:
     runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
-      - name: 'Checkout project'
-        uses: actions/checkout@v5
-
-      - name: 'Setup node 24.x'
-        uses: actions/setup-node@v5
+        uses: actions/checkout@v6
+        uses: actions/setup-node@v6
         with:
-          node-version: 24.x
-          cache: npm
-
-      - name: 'Clean install project'
+          node-version: 24
+          package-manager-cache: false
         run: npm ci
-
-      - name: 'Publish release'
         run: npm run release
-        env:
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
Update the publish-build.yml to use trusted publishers instead of an long-lived token.

Update all checkout actions to the latest version available.