### PR TITLE
Fix YAML syntax in publish-build.yml

### DIFF
--- a/.github/workflows/publish-build.yml
+++ b/.github/workflows/publish-build.yml
@@ -12,10 +12,10 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-        uses: actions/checkout@v6
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          package-manager-cache: false
-        run: npm ci
-        run: npm run release
+      uses: actions/checkout@v6
+      uses: actions/setup-node@v6
+      with:
+        node-version: 24
+        package-manager-cache: false
+      run: npm ci
+      run: npm run release


### PR DESCRIPTION
Fixed the indent issues in the publish build YAML file.

Investigate later if yamllint should be used as a action, as it will find these issues, but also issues that are not a problem for workflows (duplicate key):

```
(venv) oh48gk@APM3LH77G0QTW76 psl-linter % yamllint .github/workflows/publish-build.yml 
.github/workflows/publish-build.yml
  1:1       warning  missing document start "---"  (document-start)
  3:1       warning  truthy value should be one of [false, true]  (truthy)
  15:9      error    wrong indentation: expected 6 but found 8  (indentation)
  16:9      error    duplication of key "uses" in mapping  (key-duplicates)
  21:9      error    duplication of key "run" in mapping  (key-duplicates)
```